### PR TITLE
Quick ban when right-clicking user

### DIFF
--- a/src/commands/cmd.quickBanMessage.ts
+++ b/src/commands/cmd.quickBanMessage.ts
@@ -1,0 +1,64 @@
+import _ from 'lodash';
+import { ApplicationCommandType } from 'discord-api-types/v10';
+import { ResponsiveContentMenuCommandBuilder } from '@interactionHandling/commandBuilders.js';
+import { GuildMemberRoleManager, GuildMember } from 'discord.js';
+import { getSnowflakeMap } from '@utils.js';
+import ModMessage from './subcommands/mod/cmd.mod.message.js';
+
+export default new ResponsiveContentMenuCommandBuilder()
+  .setType(ApplicationCommandType.Message)
+  .setName('Quick Ban')
+  .setResponse(async (interaction, _interactionHandler, _command) => {
+
+    if (!interaction.isMessageContextMenu()) return;
+
+    const SNOWFLAKE_MAP = await getSnowflakeMap();
+    const QUICK_BAN_ALLOWED =
+      interaction.member?.roles instanceof GuildMemberRoleManager ?
+        interaction.member.roles.cache.hasAny(...SNOWFLAKE_MAP.Staff_Roles) :
+
+        interaction.member?.roles instanceof Array ?
+          SNOWFLAKE_MAP.Staff_Roles.some(r => (<string[]>interaction.member?.roles).includes(r)) :
+          undefined;
+
+    if (!QUICK_BAN_ALLOWED) {
+      await interaction.reply({
+        content: QUICK_BAN_ALLOWED === false ?
+          'You are not allowed to quick ban users, please DM a Sr. Staff member about this' :
+          'Failed to process command, please DM a bot developer about this',
+        ephemeral: true
+      });
+      return;
+    }
+
+    const GUILD_MEMBER_ID = interaction.targetMessage.author.id;
+
+    const GUILD_MEMBER = interaction.targetMessage.member instanceof GuildMember ? interaction.targetMessage.member : await interaction.guild?.members.fetch(GUILD_MEMBER_ID).catch();
+
+    if (!GUILD_MEMBER) {
+      return await interaction.reply({
+        content: 'Failed to find the member to be banned, please check that the member is still in the server and use the normal ban command instead',
+        ephemeral: true
+      });
+    }
+
+    const JOINED_AT = GUILD_MEMBER.joinedAt;
+
+    if (!JOINED_AT || Date.now() - JOINED_AT.getTime() > 1000 * 60 * 60 * 24 * 7) {
+      return await interaction.reply({
+        content: 'This member joined the server too long ago to be quick banned, please use the normal ban command instead',
+        ephemeral: true
+      })
+    }
+
+    ModMessage.response(interaction, _interactionHandler, ModMessage, {
+      user: GUILD_MEMBER.user,
+      'message-id': interaction.targetMessage.id,
+      'delete-message': true,
+      'action': 'ban',
+      reason: 'Banned for breaking the rules in under 7 days of joining',
+      rule: ['other'],
+      duration: '7d',
+      'private-notes': 'Quick Banned Member | No Private Notes Provided'
+    });
+  });

--- a/src/commands/cmd.quickBanUser.ts
+++ b/src/commands/cmd.quickBanUser.ts
@@ -3,14 +3,14 @@ import { ApplicationCommandType } from 'discord-api-types/v10';
 import { ResponsiveContentMenuCommandBuilder } from '@interactionHandling/commandBuilders.js';
 import { GuildMemberRoleManager, GuildMember } from 'discord.js';
 import { getSnowflakeMap } from '@utils.js';
-import ModMessage from './subcommands/mod/cmd.mod.message.js';
+import ModUser from './subcommands/mod/cmd.mod.user.js';
 
 export default new ResponsiveContentMenuCommandBuilder()
-  .setType(ApplicationCommandType.Message)
+  .setType(ApplicationCommandType.User)
   .setName('Quick Ban User')
   .setResponse(async (interaction, _interactionHandler, _command) => {
 
-    if (!interaction.isMessageContextMenu()) return;
+    if (!interaction.isUserContextMenu()) return;
 
     const SNOWFLAKE_MAP = await getSnowflakeMap();
     const QUICK_BAN_ALLOWED =
@@ -31,9 +31,9 @@ export default new ResponsiveContentMenuCommandBuilder()
       return;
     }
 
-    const GUILD_MEMBER_ID = interaction.targetMessage.author.id;
+    const GUILD_MEMBER_ID = interaction.targetUser.id;
 
-    const GUILD_MEMBER = interaction.targetMessage.member instanceof GuildMember ? interaction.targetMessage.member : await interaction.guild?.members.fetch(GUILD_MEMBER_ID).catch();
+    const GUILD_MEMBER = interaction.targetMember instanceof GuildMember ? interaction.targetMember : await interaction.guild?.members.fetch(GUILD_MEMBER_ID).catch();
 
     if (!GUILD_MEMBER) {
       return await interaction.reply({
@@ -43,6 +43,7 @@ export default new ResponsiveContentMenuCommandBuilder()
     }
 
     const JOINED_AT = GUILD_MEMBER.joinedAt;
+    console.log(JOINED_AT);
 
     if (!JOINED_AT || Date.now() - JOINED_AT.getTime() > 1000 * 60 * 60 * 24 * 7) {
       return await interaction.reply({
@@ -51,10 +52,8 @@ export default new ResponsiveContentMenuCommandBuilder()
       })
     }
 
-    ModMessage.response(interaction, _interactionHandler, ModMessage, {
+    ModUser.response(interaction, _interactionHandler, ModUser, {
       user: GUILD_MEMBER.user,
-      'message-id': interaction.targetMessage.id,
-      'delete-message': true,
       'action': 'ban',
       reason: 'Banned for breaking the rules in under 7 days of joining',
       rule: ['other'],


### PR DESCRIPTION
- Can now right-click on a user to Quick Ban
- Renamed old `Quick Ban User` command to `Quick Ban` because of how interactions are handled
- Renamed old Quick Ban file, created another new one