### PR TITLE
Add support for some User Context Menu commands

### DIFF
--- a/src/commands/cmd.quickBanMessage.ts
+++ b/src/commands/cmd.quickBanMessage.ts
@@ -1,0 +1,64 @@
+import _ from 'lodash';
+import { ApplicationCommandType } from 'discord-api-types/v10';
+import { ResponsiveContentMenuCommandBuilder } from '@interactionHandling/commandBuilders.js';
+import { GuildMemberRoleManager, GuildMember } from 'discord.js';
+import { getSnowflakeMap } from '@utils.js';
+import ModMessage from './subcommands/mod/cmd.mod.message.js';
+
+export default new ResponsiveContentMenuCommandBuilder()
+  .setType(ApplicationCommandType.Message)
+  .setName('Quick Ban')
+  .setResponse(async (interaction, _interactionHandler, _command) => {
+
+    if (!interaction.isMessageContextMenu()) return;
+
+    const SNOWFLAKE_MAP = await getSnowflakeMap();
+    const QUICK_BAN_ALLOWED =
+      interaction.member?.roles instanceof GuildMemberRoleManager ?
+        interaction.member.roles.cache.hasAny(...SNOWFLAKE_MAP.Staff_Roles) :
+
+        interaction.member?.roles instanceof Array ?
+          SNOWFLAKE_MAP.Staff_Roles.some(r => (<string[]>interaction.member?.roles).includes(r)) :
+          undefined;
+
+    if (!QUICK_BAN_ALLOWED) {
+      await interaction.reply({
+        content: QUICK_BAN_ALLOWED === false ?
+          'You are not allowed to quick ban users, please DM a Sr. Staff member about this' :
+          'Failed to process command, please DM a bot developer about this',
+        ephemeral: true
+      });
+      return;
+    }
+
+    const GUILD_MEMBER_ID = interaction.targetMessage.author.id;
+
+    const GUILD_MEMBER = interaction.targetMessage.member instanceof GuildMember ? interaction.targetMessage.member : await interaction.guild?.members.fetch(GUILD_MEMBER_ID).catch();
+
+    if (!GUILD_MEMBER) {
+      return await interaction.reply({
+        content: 'Failed to find the member to be banned, please check that the member is still in the server and use the normal ban command instead',
+        ephemeral: true
+      });
+    }
+
+    const JOINED_AT = GUILD_MEMBER.joinedAt;
+
+    if (!JOINED_AT || Date.now() - JOINED_AT.getTime() > 1000 * 60 * 60 * 24 * 7) {
+      return await interaction.reply({
+        content: 'This member joined the server too long ago to be quick banned, please use the normal ban command instead',
+        ephemeral: true
+      })
+    }
+
+    ModMessage.response(interaction, _interactionHandler, ModMessage, {
+      user: GUILD_MEMBER.user,
+      'message-id': interaction.targetMessage.id,
+      'delete-message': true,
+      'action': 'ban',
+      reason: 'Banned for breaking the rules in under 7 days of joining',
+      rule: ['other'],
+      duration: '7d',
+      'private-notes': 'Quick Banned Member | No Private Notes Provided'
+    });
+  });

--- a/src/commands/cmd.quickBanUser.ts
+++ b/src/commands/cmd.quickBanUser.ts
@@ -3,14 +3,14 @@ import { ApplicationCommandType } from 'discord-api-types/v10';
 import { ResponsiveContentMenuCommandBuilder } from '@interactionHandling/commandBuilders.js';
 import { GuildMemberRoleManager, GuildMember } from 'discord.js';
 import { getSnowflakeMap } from '@utils.js';
-import ModMessage from './subcommands/mod/cmd.mod.message.js';
+import ModUser from './subcommands/mod/cmd.mod.user.js';
 
 export default new ResponsiveContentMenuCommandBuilder()
-  .setType(ApplicationCommandType.Message)
+  .setType(ApplicationCommandType.User)
   .setName('Quick Ban User')
   .setResponse(async (interaction, _interactionHandler, _command) => {
 
-    if (!interaction.isMessageContextMenu()) return;
+    if (!interaction.isUserContextMenu()) return;
 
     const SNOWFLAKE_MAP = await getSnowflakeMap();
     const QUICK_BAN_ALLOWED =
@@ -31,9 +31,9 @@ export default new ResponsiveContentMenuCommandBuilder()
       return;
     }
 
-    const GUILD_MEMBER_ID = interaction.targetMessage.author.id;
+    const GUILD_MEMBER_ID = interaction.targetUser.id;
 
-    const GUILD_MEMBER = interaction.targetMessage.member instanceof GuildMember ? interaction.targetMessage.member : await interaction.guild?.members.fetch(GUILD_MEMBER_ID).catch();
+    const GUILD_MEMBER = interaction.targetMember instanceof GuildMember ? interaction.targetMember : await interaction.guild?.members.fetch(GUILD_MEMBER_ID).catch();
 
     if (!GUILD_MEMBER) {
       return await interaction.reply({
@@ -43,6 +43,7 @@ export default new ResponsiveContentMenuCommandBuilder()
     }
 
     const JOINED_AT = GUILD_MEMBER.joinedAt;
+    console.log(JOINED_AT);
 
     if (!JOINED_AT || Date.now() - JOINED_AT.getTime() > 1000 * 60 * 60 * 24 * 7) {
       return await interaction.reply({
@@ -51,10 +52,8 @@ export default new ResponsiveContentMenuCommandBuilder()
       })
     }
 
-    ModMessage.response(interaction, _interactionHandler, ModMessage, {
+    ModUser.response(interaction, _interactionHandler, ModUser, {
       user: GUILD_MEMBER.user,
-      'message-id': interaction.targetMessage.id,
-      'delete-message': true,
       'action': 'ban',
       reason: 'Banned for breaking the rules in under 7 days of joining',
       rule: ['other'],

--- a/src/commands/cmd.reportUser.ts
+++ b/src/commands/cmd.reportUser.ts
@@ -1,0 +1,42 @@
+import _ from 'lodash';
+import { ApplicationCommandType } from 'discord-api-types/v10';
+import { ResponsiveContentMenuCommandBuilder } from '@interactionHandling/commandBuilders.js';
+import MODALS from '@resources/modals.js';
+import { GuildMemberRoleManager } from 'discord.js';
+import { getSnowflakeMap } from '@utils.js';
+
+export default new ResponsiveContentMenuCommandBuilder()
+  .setType(ApplicationCommandType.User)
+  .setName('Report User')
+  .setResponse(async (interaction, _interactionHandler, _command) => {
+    if (!interaction.isUserContextMenu()) return;
+    _interactionHandler.addComponent(MODALS.report);
+
+    const SNOWFLAKE_MAP = await getSnowflakeMap();
+    const REPORT_ALLOWED =
+      interaction.member?.roles instanceof GuildMemberRoleManager ?
+        !interaction.member.roles.cache.hasAny(...SNOWFLAKE_MAP.Report_Banned_Roles) :
+
+        interaction.member?.roles instanceof Array ?
+          !SNOWFLAKE_MAP.Report_Banned_Roles.some(r => (<string[]>interaction.member?.roles).includes(r)) :
+          undefined;
+
+    // TODO: disallow reporting staff members
+    // TODO: change reason button
+    // TODO: disallow same user reporting the same message twice
+    if (!REPORT_ALLOWED) {
+      await interaction.reply({
+        content: REPORT_ALLOWED === false ?
+          `You are not allowed to report messages, please create a ticket in <#${SNOWFLAKE_MAP.Support_Channel}> for more info` :
+          `Failed to process command, please create a ticket in <#${SNOWFLAKE_MAP.Support_Channel}> about this`,
+        ephemeral: true
+      });
+      return;
+    }
+
+    // set the customid of the modal's text input to the message id
+    const MODAL = _.cloneDeep(MODALS.report);
+    MODAL.components[0]?.components[0]?.setCustomId(interaction.targetUser.id);
+
+    await interaction.showModal(MODAL);
+  });

--- a/src/database/collections/collections.userLogs.ts
+++ b/src/database/collections/collections.userLogs.ts
@@ -81,7 +81,7 @@ export default class UserLog {
     reason: string,
     reporter: User,
     reportedUser: User,
-    message: Message
+    message?: Message
   ) {
     const REPORT_LOG = new ReportLog(reason, reporter, reportedUser, message);
     const USER_LOG = await UserLog.getUserLog(reportedUser.id);

--- a/src/database/collections/subcollections/userLogs/collections.userLogs.reportLogs.ts
+++ b/src/database/collections/subcollections/userLogs/collections.userLogs.reportLogs.ts
@@ -39,17 +39,19 @@ export default class ReportLog {
   public readonly reason: string;
   public readonly reporter: ReturnType<typeof getUserState>;
   public readonly reportedUser: ReturnType<typeof getUserState>;
-  public readonly messageInfo: ReturnType<typeof getMessageInfo>;
+  public readonly messageInfo?: ReturnType<typeof getMessageInfo>;
 
   public constructor(
     reason: string,
     reporter: User,
     reportedUser: User,
-    message: Message
+    message: Message | undefined
   ) {
     this.reason = reason;
     this.reporter = getUserState(reporter);
     this.reportedUser = getUserState(reportedUser);
-    this.messageInfo = getMessageInfo(message);
+    if (message) {
+      this.messageInfo = getMessageInfo(message);
+    }
   }
 }

--- a/src/resources/embeds.ts
+++ b/src/resources/embeds.ts
@@ -2,11 +2,13 @@ import path from 'node:path';
 import chokidar from 'chokidar';
 import { getDirectoryFromFileURL, getModulesInFolder } from '@utils.js';
 import messageReport from './embeds/embeds.messageReport.js';
+import userReport from './embeds/embeds.userReport.js';
 import moderationLogs from './embeds/embeds.moderationLogs.js';
 import moderationNotice from './embeds/embeds.moderationNotice.js';
 
 const EMBEDS = {
   messageReport,
+  userReport,
   moderationLogs,
   moderationNotice
 };

--- a/src/resources/embeds/embeds.messageReport.ts
+++ b/src/resources/embeds/embeds.messageReport.ts
@@ -27,30 +27,36 @@ export default async function messageReport(reporter: User, reason: string, mess
   const EMBED = new MessageEmbed()
     .setAuthor({ name: 'Reported By', iconURL: reporter.displayAvatarURL() })
     .setDescription(`> ${reporter}`)
-    .addField('Reason', reason, true)
-    .addField('This user has been reported', await reportsCountSummary(message.author.id), true)
-    .addField('\u200b', '\u200b')
-    .addField(
-      'Message Link',
-      `[Jump to message](https://discord.com/channels/${guild.id}/${message.channel.id}/${message.id})`,
-      true
-    )
-    .addField('Message Channel', message.channel.toString(), true)
-    .addField('Reported User', message.author.toString(), true)
-    .addField('\u200b', '\u200b')
+    .addFields([
+      {name: 'Reason', value: reason, inline: true},
+      {name: 'This user has been reported', value: await reportsCountSummary(message.author.id), inline: true},
+      {name: '\u200b', value: '\u200b'},
+      {
+        name:'Message Link',
+        value: `[Jump to message](https://discord.com/channels/${guild.id}/${message.channel.id}/${message.id})`,
+        inline: true
+      },
+      {name: 'Message Channel', value: message.channel.toString(), inline: true},
+      {name: 'Reported User', value: message.author.toString(), inline: true},
+      {name: '\u200b', value: '\u200b'},
+    ])
     .setTimestamp();
 
-  if (message.content) EMBED.addField(
-    'Reported Message Content',
-    message.content,
-    false
-  );
+  if (message.content) EMBED.addFields([
+    {
+      name:'Reported Message Content',
+      value:message.content,
+      inline: false
+    }
+  ]);
 
-  if (message.attachments.size) EMBED.addField(
-    'Reported Message Attachments',
-    message.attachments.map(a => a.url).join('\n'),
-    false
-  );
+  if (message.attachments.size) EMBED.addFields([
+    {
+      name: 'Reported Message Attachments',
+      value: message.attachments.map(a => a.url).join('\n'),
+      inline: false
+    }
+  ]);
 
   return EMBED;
 }

--- a/src/resources/embeds/embeds.userReport.ts
+++ b/src/resources/embeds/embeds.userReport.ts
@@ -1,0 +1,44 @@
+import { MessageEmbed, Snowflake, User, VoiceState } from 'discord.js';
+import COLLECTIONS from '@database/collections.js';
+
+function pushReportsCount(array: string[], length: number, prevTimeLength: number, time: string) {
+  if (length && length > prevTimeLength)
+    array.push(`**${length}** ${length === 1 ? 'time' : 'times'} in __${time}__`);
+}
+
+async function reportsCountSummary(userID: Snowflake) {
+  const LOGS = (await COLLECTIONS.UserLog.getUserLog(userID)).reportLogs;
+  const DAY = LOGS.filter(log => log.timestamp > Date.now() - 86400000).length;
+  const WEEK = LOGS.filter(log => log.timestamp > Date.now() - 604800000).length;
+  const MONTH = LOGS.filter(log => log.timestamp > Date.now() - 2628000000).length;
+  const YEAR = LOGS.filter(log => log.timestamp > Date.now() - 31536000000).length;
+  const ALL = LOGS.length;
+
+  const LINES: string[] = [];
+  pushReportsCount(LINES, DAY, 0, 'the past 24 hours');
+  pushReportsCount(LINES, WEEK, DAY, 'the past 7 days');
+  pushReportsCount(LINES, MONTH, WEEK, 'the past 30 days');
+  pushReportsCount(LINES, YEAR, MONTH, 'the past 365 days');
+  pushReportsCount(LINES, ALL, YEAR, 'total');
+  return LINES.join('\n');
+}
+
+export default async function messageReport(reporter: User, reason: string, user: User, voice: VoiceState) {
+  const EMBED = new MessageEmbed()
+    .setAuthor({ name: 'Reported By', iconURL: reporter.displayAvatarURL() })
+    .setDescription(`> ${reporter}`)
+    .addField('Reason', reason, true)
+    .addField('This user has been reported', await reportsCountSummary(user.id), true)
+    .addField('\u200b', '\u200b')
+    .addField('Reported User', user.toString(), true)
+    .addField('\u200b', '\u200b')
+    .setTimestamp();
+
+  if (voice.channel) {
+    EMBED.addFields([
+      {name: 'Current Voice Channel', value: voice.channel?.toString(), inline: true}
+    ])
+  }
+
+  return EMBED;
+}

--- a/src/resources/embeds/embeds.userReport.ts
+++ b/src/resources/embeds/embeds.userReport.ts
@@ -27,11 +27,13 @@ export default async function messageReport(reporter: User, reason: string, user
   const EMBED = new MessageEmbed()
     .setAuthor({ name: 'Reported By', iconURL: reporter.displayAvatarURL() })
     .setDescription(`> ${reporter}`)
-    .addField('Reason', reason, true)
-    .addField('This user has been reported', await reportsCountSummary(user.id), true)
-    .addField('\u200b', '\u200b')
-    .addField('Reported User', user.toString(), true)
-    .addField('\u200b', '\u200b')
+    .addFields([
+      {name: 'Reason', value: reason, inline: true},
+      {name: 'This user has been reported', value: await reportsCountSummary(user.id), inline: true},
+      {name: '\u200b', value: '\u200b'},
+      {name: 'Reported User', value: user.toString(), inline: true},
+      {name: '\u200b', value: '\u200b'},
+    ])
     .setTimestamp();
 
   if (voice.channel) {

--- a/src/resources/modals/modals.report.ts
+++ b/src/resources/modals/modals.report.ts
@@ -4,6 +4,7 @@ import { ResponsiveModal } from '@interactionHandling/componentBuilders.js';
 import { getSnowflakeMap } from '@utils.js';
 import EMBEDS from '../embeds.js';
 import type InteractionHandler from '@interactionHandling/interactionHandler.js';
+import { ChannelType } from 'discord-api-types/v10';
 
 export default new ResponsiveModal()
   .setCustomId('modals.report')
@@ -67,6 +68,10 @@ export default new ResponsiveModal()
           await reportLog.react('👍');
         }));
 
+        if (interaction.channel?.type == ChannelType.GuildVoice.toString()) {
+          await interaction.user.send('Thank you for reporting this user. The staff will take action shortly');
+        }
+
         await interaction.followUp({
           content: 'User Reported',
           ephemeral: true
@@ -79,6 +84,11 @@ export default new ResponsiveModal()
         content: `Failed reporting, please create a ticket in <#${SNOWFLAKE_MAP.Support_Channel}> about this`,
         ephemeral: true
       });
+
+      // If the report message is too long, it will fail checking if it's a VC channel for some reason
+      await interaction.user.send(
+        `Failed reporting, please create a ticket in <#${SNOWFLAKE_MAP.Support_Channel}> about this`);
+
       throw e;
     }
   });


### PR DESCRIPTION
What this does so far:

- Can quick ban member by right-clicking the user instead of just a message (useful for VC moderation and when the user hasn't sent a message)
- Can report member by right-click the user (useful for VC moderation and when the user has an inappropriate bio)

Todo:

- [x] Cleanup Deprecated `MessageEmbed.addField()`s that are used to make report embeds
- [x] Fix interaction not being responded to with a message <- this is due to the way discord handles webhooks. It's very annoying and hard to explain -_-; solved by DMing a user if the report fails or if they report someone in a VC