### PR TITLE
templates.actioncommand: check for previous interaction defers before deferring

### DIFF
--- a/src/resources/commandTemplates/templates.ActionCommand.ts
+++ b/src/resources/commandTemplates/templates.ActionCommand.ts
@@ -469,7 +469,7 @@ export default class ActionCommand extends ResponsiveSlashCommandSubcommandBuild
       throw new Error('An invalid interaction type was passed into the ActionCommand response method');
 
     if (options === undefined) options = {};
-    await interaction.deferReply({ ephemeral: true });
+    if (!interaction.deferred && !interaction.replied) await interaction.deferReply({ ephemeral: true });
 
     const SNOWFLAKE_MAP = await getSnowflakeMap();
 


### PR DESCRIPTION
Previously, running commands such as quickban would produce errors like this

```
[unhandledException] Error [InteractionAlreadyReplied]: The reply to this interaction has already been sent or deferred.
    at UserContextMenuCommandInteraction.deferReply (/home/container/node_modules/discord.js/src/structures/interfaces/InteractionResponses.js:67:46)
    at ActionCommand.response (file:///home/container/dist/resources/commandTemplates/templates.ActionCommand.js:324:27)
    at ResponsiveContextMenuCommandBuilder.response (file:///home/container/dist/commands/cmd.quickBanUser.js?v=1688400143270:47:13)
    at async InteractionHandler.respond (file:///home/container/dist/interactionHandling/interactionHandler.js:56:13)
    at async Client.<anonymous> (file:///home/container/dist/interactionHandling/interactionHandler.js:35:51)
```

This is because sometimes deferred interactions are passed into the action command template (e.g. in quickban).

I have decided to keep compatibility with both pre-deferred and not-deferred interactions rather than either requiring the other side to defer (and changing instances where it does not) or keeping the previous behavior (and changing instances where it does)