### PR TITLE
improve /mod toggle

### DIFF
--- a/src/commands/mod/toggle.ts
+++ b/src/commands/mod/toggle.ts
@@ -40,8 +40,6 @@ export default new ResponsiveSlashCommandSubcommandBuilder()
       return;
     }
 
-    BUTTONS.toggleLog.components.forEach(i => _interactionHandler.addComponent(i));
-
     const user = interaction.options.getUser('user', true);
     const infraction = interaction.options.getString('infraction', true);
 
@@ -53,11 +51,12 @@ export default new ResponsiveSlashCommandSubcommandBuilder()
       return;
     }
 
+    const actionRow = BUTTONS.toggleLog(LOG.isHidden);
+    actionRow.components.forEach(i => _interactionHandler.addComponent(i));
+
     await interaction.followUp({
-      embeds: [await EMBEDS.toggleLog(user, infraction)],
-      components: [
-        BUTTONS.toggleLog
-      ],
-      ephemeral: true
+      embeds: [await EMBEDS.toggleLog(user, infraction, LOG)],
+      components: [BUTTONS.toggleLog(LOG.isHidden)],
+      ephemeral: true,
     });
   });

--- a/src/resources/buttons/toggleLog.ts
+++ b/src/resources/buttons/toggleLog.ts
@@ -1,143 +1,20 @@
-import { ActionRowBuilder, ButtonStyle, Client, Embed, type Interaction } from 'discord.js';
+import { ActionRowBuilder, ButtonStyle, type Interaction } from 'discord.js';
 import { ResponsiveMessageButton } from '@interactionHandling/componentBuilders.js';
 import type InteractionHandler from '@interactionHandling/interactionHandler.js';
-import EMBEDS from '@resources/embeds.js'
-import { getSnowflakeMap } from '@utils.js';
-import COLLECTIONS from '@database/collections.js';
+import MODALS from '@resources/modals.js';
 
-function get_infraction(embed: Embed) {
-  const regex = /Infraction ID: ([0-9]+)/gm;
-  const match = regex.exec(embed.footer?.text as string);
-  if (!match) return -1;
-  return Number(match[1]);
+export default function toggleLog(currentlyHidden: boolean) {
+  return new ActionRowBuilder<ResponsiveMessageButton>()
+    .addComponents([
+      new ResponsiveMessageButton()
+        .setCustomId(`${currentlyHidden ? 'Show' : 'Hide'} Infraction`)
+        .setLabel(currentlyHidden ? 'Show' : 'Hide')
+        .setEmoji({ name: currentlyHidden ? '🐇' : '🪄' })
+        .setStyle(currentlyHidden ? ButtonStyle.Success : ButtonStyle.Danger)
+        .setResponse(async (interaction: Interaction, _interactionHandler: InteractionHandler, _command) => {
+          if (!interaction.isButton()) return;
+          _interactionHandler.addComponent(MODALS.toggleLog);
+          await interaction.showModal(MODALS.toggleLog);
+        }),
+    ]);
 }
-
-async function get_log_user(client: Client, embed: Embed) {
-  const regex = /> <@([0-9]+)>/gm;
-  const match = regex.exec(embed.description as string);
-  if (!match || !match[1]) return undefined;
-
-  return await client.users.fetch(match[1]);
-}
-
-export default new ActionRowBuilder<ResponsiveMessageButton>()
-  .addComponents([
-    new ResponsiveMessageButton()
-      .setCustomId('Hide Infraction')
-      .setLabel('Hide')
-      .setEmoji({ name: '🪄' })
-      .setStyle(ButtonStyle.Danger)
-      .setResponse(async (interaction: Interaction, _interactionHandler: InteractionHandler, _command) => {
-        if (!interaction.isButton()) return;
-
-        const this_embed = interaction.message.embeds[0] as Embed;
-        const infraction = get_infraction(this_embed);
-
-        if (infraction === -1) {
-          await interaction.followUp('Could not find the infraction ID; tell the devs');
-          return;
-        }
-
-        const user = await get_log_user(interaction.client, this_embed);
-
-        if (!user) {
-          await interaction.followUp('Could not find the user; tell the devs');
-          return;
-        }
-
-        COLLECTIONS.UserLog.setHidden(user.id, infraction - 1, true);
-
-        const SNOWFLAKE_MAP = await getSnowflakeMap();
-        const sr_notify_channel = await interaction.client.channels.fetch(SNOWFLAKE_MAP.Sr_Notify_Channel);
-
-        if (!sr_notify_channel?.isTextBased()) {
-          await interaction.followUp('Could not send to sr. staff.\n' +
-            'Tell the devs:\n> Badeline says the channel is not a text channel (`line 88`)');
-          return;
-        }
-
-        try {
-          sr_notify_channel.send({
-            content: `${SNOWFLAKE_MAP.Admin_Roles.map(u => `<@&${u}>`).join(', ')}`,
-            embeds: [
-              await EMBEDS.toggleLogNotice(
-                user,
-                infraction.toString(),
-                interaction.user,
-              )],
-            allowedMentions: { parse: [], roles: SNOWFLAKE_MAP.Admin_Roles },
-          });
-
-        } catch (e) {
-          console.error(e);
-          interaction.followUp('Could not notify sr. staff. Tell the devs to look around `line 60`');
-          return;
-        }
-
-        await interaction.update({
-          content: 'This infraction has been hidden.',
-          embeds: []
-        });
-
-        return;
-      }),
-    new ResponsiveMessageButton()
-      .setCustomId('Show Infraction')
-      .setLabel('Show')
-      .setEmoji({ name: '🐇' })
-      .setStyle(ButtonStyle.Success)
-      .setResponse(async (interaction: Interaction, _interactionHandler: InteractionHandler, _command) => {
-        if (!interaction.isButton()) return;
-
-        const this_embed = interaction.message.embeds[0] as Embed;
-        const infraction = get_infraction(this_embed);
-
-        if (infraction === -1) {
-          await interaction.followUp('Could not find the infraction ID; tell the devs');
-          return;
-        }
-
-        const user = await get_log_user(interaction.client, this_embed);
-
-        if (!user) {
-          await interaction.followUp('Could not find the user; tell the devs');
-          return;
-        }
-
-        COLLECTIONS.UserLog.setHidden(user.id, infraction - 1, false);
-
-        const SNOWFLAKE_MAP = await getSnowflakeMap();
-        const sr_notify_channel = await interaction.client.channels.fetch(SNOWFLAKE_MAP.Sr_Notify_Channel);
-
-        if (!sr_notify_channel?.isTextBased()) {
-          await interaction.followUp('Could not send to sr. staff.\n' +
-            'Tell the devs:\n> Badeline says the channel is not a text channel (`line 88`)');
-          return;
-        }
-
-        try {
-          sr_notify_channel.send({
-            content: `${SNOWFLAKE_MAP.Admin_Roles.map(u => `<@&${u}>`).join(', ')}`,
-            embeds: [
-              await EMBEDS.toggleLogNotice(
-                user,
-                infraction.toString(),
-                interaction.user,
-              )],
-            allowedMentions: { parse: [], roles: SNOWFLAKE_MAP.Admin_Roles },
-          });
-
-        } catch (e) {
-          console.error(e);
-          interaction.followUp('Could not notify sr. staff. Tell the devs to look around `line 117`');
-          return;
-        }
-
-        await interaction.update({
-          content: 'This infraction has made visible.',
-          embeds: []
-        });
-
-        return;
-      })
-  ]);

--- a/src/resources/embeds/toggleLog.ts
+++ b/src/resources/embeds/toggleLog.ts
@@ -1,6 +1,6 @@
 import { EmbedBuilder, User } from 'discord.js';
-import COLLECTIONS from '@database/collections.js';
 import { getRules } from '@utils.js';
+import type ModerationLog from '@database/collections/userLogs/moderationLogs.js';
 
 // TODO: give more info and polish layout
 
@@ -14,16 +14,8 @@ const pastTenseActions: Record<string, string> = {
   add_mature: 'Received the mature role', // legacy
 }
 
-export default async function toggleLog(user: User, infraction: string) {
-  const LOGS = (await COLLECTIONS.UserLog.getUserLog(user.id)).moderationLogs;
-
-  const LOG = LOGS[parseInt(infraction) - 1];
-
+export default async function toggleLog(user: User, infraction: string, LOG: ModerationLog) {
   const RULES = await getRules();
-
-  if (LOG === undefined) {
-    return new EmbedBuilder().setDescription('Infraction not found');
-  }
 
   const rule = RULES[LOG.rule];
   const ruleText = rule !== undefined ? `Rule ${rule?.ruleNumber} (${LOG.rule})` : `Deleted rule (${LOG.rule})`;
@@ -39,7 +31,7 @@ export default async function toggleLog(user: User, infraction: string) {
 
   const EMBED = new EmbedBuilder()
     .setAuthor({ name: 'Logs for', iconURL: user.displayAvatarURL(), url: `https://discord.com/users/${user.id}` })
-    .setDescription(`> <@${user.id}> (\`${user.username}\`)`)
+    .setDescription(`> <@${user.id}> (\`${user.username}\`)\n(currently ${LOG.isHidden ? 'hidden' : 'shown'})`)
     .setFooter({ text: `Infraction ID: ${infraction}` })
     .addFields([
       {

--- a/src/resources/embeds/toggleLogNotice.ts
+++ b/src/resources/embeds/toggleLogNotice.ts
@@ -14,7 +14,7 @@ const pastTenseActions: Record<string, string> = {
   add_mature: 'Received the mature role', // legacy
 }
 
-export default async function toggleLogNotice(user: User, infraction: string, moderator: User) {
+export default async function toggleLogNotice(user: User, infraction: string, moderator: User, reason: string, hidden: boolean) {
   const LOGS = (await COLLECTIONS.UserLog.getUserLog(user.id)).moderationLogs;
 
   const LOG = LOGS[parseInt(infraction) - 1];
@@ -38,7 +38,7 @@ export default async function toggleLogNotice(user: User, infraction: string, mo
   }
 
   const EMBED = new EmbedBuilder()
-    .setAuthor({ name: 'Log toggled by ', iconURL: moderator.displayAvatarURL(), url: `https://discord.com/users/${moderator.id}` })
+    .setAuthor({ name: `Log toggled (now ${hidden ? 'hidden' : 'shown'}) by`, iconURL: moderator.displayAvatarURL(), url: `https://discord.com/users/${moderator.id}` })
     .setDescription(`> <@${moderator.id}> (\`${moderator.username}\`)`)
     .setFooter({ text: `Moderated User: @${user.username} (${user.id})` })
     .addFields([
@@ -56,6 +56,10 @@ export default async function toggleLogNotice(user: User, infraction: string, mo
         name: `${pastTenseActions[LOG.action] ?? 'ERROR'} <t:${Math.floor(LOG.timestamp / 1000)}:R>`,
         value: messageDeletedText,
         inline: true
+      },
+      {
+        name: 'Reason',
+        value: reason
       }
     ]);
   return EMBED;

--- a/src/resources/modals.ts
+++ b/src/resources/modals.ts
@@ -3,10 +3,12 @@ import chokidar from 'chokidar';
 import { getDirectoryFromFileURL, getModulesInFolder } from '@utils.js';
 import report from './modals/report.js';
 import calmdown from './modals/calmdown.js';
+import toggleLog from './modals/toggleLog.js';
 
 const MODALS = {
   report,
-  calmdown
+  calmdown,
+  toggleLog,
 };
 
 // TODO: a more centralised way to reload?

--- a/src/resources/modals/toggleLog.ts
+++ b/src/resources/modals/toggleLog.ts
@@ -1,0 +1,107 @@
+import { ActionRowBuilder, Client, ComponentType, Embed, TextInputBuilder, TextInputStyle } from 'discord.js';
+import COLLECTIONS from '@database/collections.js';
+import { ResponsiveModal } from '@interactionHandling/componentBuilders.js';
+import type InteractionHandler from '@interactionHandling/interactionHandler.js';
+import EMBEDS from '@resources/embeds.js';
+import { getSnowflakeMap } from '@utils.js';
+
+function get_infraction(embed?: Embed) {
+  if (!embed?.footer?.text) return -1;
+
+  const regex = /Infraction ID: ([0-9]+)/gm;
+  const match = regex.exec(embed.footer.text);
+  if (!match) return -1;
+  return Number(match[1]);
+}
+
+async function get_log_user(client: Client, embed?: Embed) {
+  if (!embed?.description) return;
+
+  const regex = /> <@([0-9]+)>/gm;
+  const match = regex.exec(embed.description);
+  if (!match || !match[1]) return;
+
+  return await client.users.fetch(match[1]);
+}
+
+export default new ResponsiveModal()
+  .setCustomId('modals.toggleLog')
+  .setTitle('Toggle Log')
+  .addComponents(
+    new ActionRowBuilder<TextInputBuilder>().addComponents(
+      new TextInputBuilder()
+        .setLabel('Reason')
+        .setCustomId('modals.toggleLog.reason')
+        .setPlaceholder('An explanation of why the log entry is being toggled.')
+        .setStyle(TextInputStyle.Paragraph)
+        .setMaxLength(1024)
+        .setRequired(true),
+    ),
+  ).setResponse(async (interaction, _interactionHandler: InteractionHandler, _command) => {
+    if (!interaction.isModalSubmit()) return;
+    await interaction.deferUpdate();
+
+    const REASON = interaction.fields.getTextInputValue('modals.toggleLog.reason');
+
+    const this_embed = interaction.message?.embeds[0];
+    const infraction = get_infraction(this_embed);
+
+    if (infraction === -1) {
+      await interaction.followUp('Could not find the infraction ID; tell the devs');
+      return;
+    }
+
+    const user = await get_log_user(interaction.client, this_embed);
+
+    if (!user) {
+      await interaction.followUp('Could not find the user; tell the devs');
+      return;
+    }
+
+    const button = interaction.message?.components[0]?.components[0];
+    const hide = button?.type === ComponentType.Button ? button.label === 'Hide' ? true : button.label === 'Show' ? false : null : null;
+
+    if (hide === null) {
+      await interaction.followUp('Could not determine whether to hide/show the entry; tell the devs');
+      return;
+    }
+
+    COLLECTIONS.UserLog.setHidden(user.id, infraction - 1, hide);
+
+    const SNOWFLAKE_MAP = await getSnowflakeMap();
+    const sr_notify_channel = await interaction.client.channels.fetch(SNOWFLAKE_MAP.Sr_Notify_Channel);
+
+    if (!sr_notify_channel?.isTextBased()) {
+      await interaction.followUp('Could not send to sr. staff.\n' +
+        'Tell the devs:\n> Badeline says the channel is not a text channel (`line 88`)');
+      return;
+    }
+
+    try {
+      sr_notify_channel.send({
+        content: `${SNOWFLAKE_MAP.Admin_Roles.map(u => `<@&${u}>`).join(', ')}`,
+        embeds: [
+          await EMBEDS.toggleLogNotice(
+            user,
+            infraction.toString(),
+            interaction.user,
+            REASON,
+            hide,
+          )],
+        allowedMentions: { parse: [], roles: SNOWFLAKE_MAP.Admin_Roles },
+      });
+
+    } catch (e) {
+      console.error(e);
+      interaction.followUp('Could not notify sr. staff. Tell the devs to look around `line 60`');
+      return;
+    }
+
+    await interaction.editReply({
+      content: `This infraction has been ${hide ? 'hidden' : 'made visible'}.`,
+      components: [],
+      embeds: [],
+    });
+
+    return;
+  });


### PR DESCRIPTION
- embed now shows whether it is currently hidden or shown
- now only shows the button to change the status and doesn't allow re-hiding a hidden entry or vice versa
- now requires a reason and shows a modal to input the reason when the button is pressed + logs the reason
- the log entry now informs which action was taken (whether it was hidden or shown)
- cleanup: removed a lot of duplicate code and fixed some missing trailing commas and similar (didn't clean up everything, just things in proximity of existing changes / in the same files)

tested:
- can hide an entry
- can show an entry
- logging works as before with added features
- `/mod toggle` on a nonexistent entry still shows "Infraction not found" gracefully